### PR TITLE
Cleanup code and fix rounding issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,8 @@ function nstr(
     // Truncate at the start of the detected artifact
     let truncated = str.substring(0, patternStart)
 
-    // Special handling for runs of 9s → may require rounding up
     if (patternChar === '9') {
+      // If we found a run of 9s, round up properly
       const beforeNines = truncated
       const rounded = Number.parseFloat(beforeNines)
 
@@ -75,10 +75,7 @@ function nstr(
       // Round away from zero
       const roundedUp = rounded < 0 ? rounded - increment : rounded + increment
 
-      // Use rounded version if it's cleaner
-      if (roundedUp.toString().length <= beforeNines.length) {
-        truncated = roundedUp.toString()
-      }
+      truncated = roundedUp.toFixed(decimals)
     }
 
     result = truncated


### PR DESCRIPTION
## Cleanup Code

- remove redundant removing of trailing zeros
- remove unnecessary if conditions from normalizing negative zero
- change some comments to be more readable

## Fix Rounding Issues

Fix 2 edge cases with test 15 and 17, those tests were failing on main branch code.

Test were failing:

```sh
Test 15: 456.7899999945679 → "456.78" ❌
  Expected: "456.79"
Test 17: 2468.1359999990245 → "2468.135" ❌
  Expected: "2468.136"
```

Right now, all test were passing.