### PR TITLE
Remove redundant assignment when `0`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ function nstr(
     }
     
     // Handle edge cases: "-0." becomes "0", "0." becomes "0", "-0" becomes "0"
-    if (result === '-0.' || result === '0.' || result === '-0' || result === '0') {
+    if (result === '-0.' || result === '0.' || result === '-0') {
       result = '0'
     }
     
@@ -105,7 +105,7 @@ function nstr(
   }
   
   // Handle edge cases: "-0." becomes "0", "0." becomes "0", "-0" becomes "0"
-  if (result === '-0.' || result === '0.' || result === '-0' || result === '0') {
+  if (result === '-0.' || result === '0.' || result === '-0') {
     result = '0'
   }
   


### PR DESCRIPTION
The `if` statement checks for `0` and then assigns it back to `0`.

We can skip this redundant assignment.